### PR TITLE
ci(ohrisk): add action smoke workflow

### DIFF
--- a/.github/workflows/ohrisk-smoke.yml
+++ b/.github/workflows/ohrisk-smoke.yml
@@ -1,0 +1,35 @@
+name: Ohrisk Action Smoke
+
+on:
+  push:
+    branches:
+      - task/ohrisk-action-smoke
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  ohrisk:
+    name: Run Ohrisk action
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Scan license risk
+        uses: 0disoft/ohrisk@main
+        with:
+          command: scan
+          format: html
+          output: reports/ohrisk.html
+          prod: "true"
+          fail-on: ""
+
+      - name: Upload report
+        uses: actions/upload-artifact@v4
+        with:
+          name: ohrisk-html
+          path: reports/ohrisk.html

--- a/.github/workflows/ohrisk-smoke.yml
+++ b/.github/workflows/ohrisk-smoke.yml
@@ -29,7 +29,7 @@ jobs:
           fail-on: ""
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ohrisk-html
           path: reports/ohrisk.html


### PR DESCRIPTION
## Summary
- Add a dedicated `Ohrisk Action Smoke` workflow for the `task/ohrisk-action-smoke` branch and manual dispatch.
- Exercise `0disoft/ohrisk@main` with HTML report generation and upload the report artifact using `actions/upload-artifact@v7`.

## Verification
- GitHub Actions smoke run `28319117832` completed successfully on `1abd491`.
- The run log downloaded `actions/upload-artifact@v7` and did not show the Node.js 20 deprecation warning seen with `actions/upload-artifact@v4`.
- `git diff --check main...HEAD` passed locally.

## Notes
- Local `.github/workflows/pages.yml` changes were pre-existing working-tree WIP and are not part of this PR.